### PR TITLE
Ensure fewer notify errors  get sent to Sentry

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -48,7 +48,7 @@ class App < Sinatra::Base
     logger.info(sns_message.to_s) if sns_message.type == "SubscriptionConfirmation"
 
     if sns_message.sponsor_request?
-      WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
+      WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:, logger:).execute
     else
       WifiUser::UseCase::EmailJourneyHandler.new(from_address: sns_message.from_address).execute
     end

--- a/lib/wifi_user/use_case/sms_response.rb
+++ b/lib/wifi_user/use_case/sms_response.rb
@@ -14,8 +14,6 @@ class WifiUser::UseCase::SmsResponse
       WifiUser::SMSSender.send_signup_instructions(phone_number:, sms_content:, personalisation:)
     end
   rescue Notifications::Client::BadRequestError => e
-    raise e unless e.message.include? "ValidationError"
-
-    @logger.warn("Failed to send email: #{e.message}")
+    @logger.warn("Failed to send SMS: #{e.message}")
   end
 end

--- a/lib/wifi_user/use_case/sponsor_journey_handler.rb
+++ b/lib/wifi_user/use_case/sponsor_journey_handler.rb
@@ -1,7 +1,8 @@
 class WifiUser::UseCase::SponsorJourneyHandler
   include WifiUser::EmailAllowListChecker
 
-  def initialize(sns_message:)
+  def initialize(sns_message:, logger: Logger.new($stdout))
+    @logger = logger
     @sns_message = sns_message
   end
 
@@ -42,9 +43,8 @@ private
     else
       WifiUser::SMSSender.send_sponsor_sms(sponsee_user)
     end
-  rescue Notifications::Client::RequestError => e
-    raise unless e.message.include?("ValidationError")
-
+  rescue Notifications::Client::BadRequestError => e
+    @logger.info(e.message)
     false
   else
     true

--- a/spec/features/sponsor_journey_spec.rb
+++ b/spec/features/sponsor_journey_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe App do
       end
       it "sends a receipt when a sponsee email has failed to send" do
         write_email_to_s3(body: "07701001111\njohn@nongov.uk", bucket_name:, object_key:)
-        error = Notifications::Client::RequestError.new(double(body: "ValidationError", code: 200))
+        error = Notifications::Client::BadRequestError.new(double(body: "Error", code: 400))
         allow(Services.notify_client).to receive(:send_email).with(hash_including(template_id: "sponsor_credentials_email_id")).and_raise error
         allow(Services.notify_client).to receive(:send_sms).with(hash_including(template_id: "credentials_sms_id")).and_raise error
 

--- a/spec/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -81,7 +81,7 @@ describe WifiUser::UseCase::SmsResponse do
     context "with an email address validation error" do
       before do
         allow(notify_client).to receive(:send_sms).and_raise(Notifications::Client::BadRequestError,
-                                                             OpenStruct.new(code: 500, body: "ValidationError"))
+                                                             OpenStruct.new(code: 400, body: "ValidationError"))
       end
       it "doesn't raise error when the email is not valid" do
         expect {
@@ -90,7 +90,7 @@ describe WifiUser::UseCase::SmsResponse do
       end
       it "logs the attempt" do
         subject.execute(contact: phone_number, sms_content: "Go")
-        expect(logger).to have_received(:warn).with(/Failed to send email/)
+        expect(logger).to have_received(:warn).with(/Failed to send SMS/)
       end
       it "does not create a user" do
         expect {
@@ -100,13 +100,13 @@ describe WifiUser::UseCase::SmsResponse do
     end
     context "with an error that is not a email address validation error" do
       before do
-        allow(notify_client).to receive(:send_sms).and_raise(Notifications::Client::BadRequestError,
-                                                             OpenStruct.new(code: 500, body: "Something"))
+        allow(notify_client).to receive(:send_sms).and_raise(Notifications::Client::ClientError,
+                                                             OpenStruct.new(code: 450, body: "Something"))
       end
       it "re-raises the error" do
         expect {
           subject.execute(contact: "447700900003", sms_content: "Go")
-        }.to raise_error(Notifications::Client::BadRequestError)
+        }.to raise_error(Notifications::Client::ClientError)
       end
       it "does not create a user" do
         expect {


### PR DESCRIPTION
BadRequestErrors (400) are non-fatal errors such as the phone number not being formatted correctly. This is a more
specific error than RequestErrors and these should not end up in Sentry, but should be logged.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2059
